### PR TITLE
fix syntax line highlighting issue on horizontal scroll

### DIFF
--- a/styles/theme.css
+++ b/styles/theme.css
@@ -558,7 +558,9 @@ input {
     border-top-left-radius: 0px;
     border-top-right-radius: 0px;
 }
-
+.remark-code-title + pre > .code-block{
+    display: grid
+}
 /* Code Line Highlight */
 .mdx-marker {
     display: block;


### PR DESCRIPTION
fixed it by making change to `code-block` class, that is grand-parent of `mdx-marker` which is facing the issue and make it to have a `display: grid;` css style.
 #243 