### PR TITLE
Fix selectPeers js/react switching tabs

### DIFF
--- a/docs/javascript/v2/guides/useful-selectors.mdx
+++ b/docs/javascript/v2/guides/useful-selectors.mdx
@@ -56,9 +56,9 @@ const isInPreview = useHMSStore(selectIsInPreview);
 `selectPeerCount` returns the number of peers inside the room. If you have turned on
 peer list in preview, this count won't include the local peer if they're still in preview.
 
-<Tabs id="peers" items={['Javascript', 'React']} />
+<Tabs id="peerCount items={['Javascript', 'React']} />
 
-<Tab id='peers-0'>
+<Tab id='peerCount-0'>
 
 ```js
 const count = hmsStore.getState(selectPeerCount);
@@ -66,7 +66,7 @@ const count = hmsStore.getState(selectPeerCount);
 
 </Tab>
 
-<Tab id='peers-1'>
+<Tab id='peerCount-1'>
 
 ```jsx
 const count = useHMSStore(selectPeerCount);


### PR DESCRIPTION
- `selectPeerCount` and `selectPeers` have the same id so that tabs were not working