### PR TITLE
trim vale accept by using backticks

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# See example
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+/.github/styles @arjunattam @Nixon-Samuel

--- a/.github/styles/Vocab/HMSVocab/accept.txt
+++ b/.github/styles/Vocab/HMSVocab/accept.txt
@@ -104,8 +104,3 @@ stringified
 ProGuard
 errMsg
 viewport
-recording_enabled
-max_width
-max_height
-recording_single_file_per_layer_enabled
-recording_vod_playlist_enabled

--- a/docs/server-side/v2/changelog/release-notes.mdx
+++ b/docs/server-side/v2/changelog/release-notes.mdx
@@ -10,8 +10,8 @@ This Changelog highlights notable changes to the 100ms server-side API, such as 
 #### Additions
 
 -   Added support for securing webhooks by whitelisting 100ms [NAT gateway IP addresses](/server-side/v2/introduction/webhook#ip-whitelisting).
--   Added new fields in [Beam events](/server-side/v2/introduction/webhook#rtmp-streaming-and-browser-recording-events) -- recording_enabled, max_width, & max_height
--   Added new fields in [HLS events](/server-side/v2/introduction/webhook#hls-streaming-events) -- recording_single_file_per_layer_enabled & recording_vod_playlist_enabled
+-   Added new fields in [Beam events](/server-side/v2/introduction/webhook#rtmp-streaming-and-browser-recording-events): `recording_enabled`, `max_width`, and `max_height`
+-   Added new fields in [HLS events](/server-side/v2/introduction/webhook#hls-streaming-events): `recording_single_file_per_layer_enabled` and `recording_vod_playlist_enabled`
 -   Added `hlsDestination` response object in [retrieve a specific template API](/server-side/v2/policy/retrieve-a-template)
 
 #### Developer experience


### PR DESCRIPTION
2 changes
* reducing vale `accept.txt` by using backticks for 100ms API strings
* added codeowners to add me and Nixon as reviewers when the `accept.txt` file is updated