### PR TITLE
Update on rtmp-recording.mdx

### DIFF
--- a/docs/javascript/v2/features/rtmp-recording.mdx
+++ b/docs/javascript/v2/features/rtmp-recording.mdx
@@ -44,7 +44,7 @@ If both are required, they have to be started together by providing both RTMP In
 async start() {
     const params = {
         meetingURL: "",
-        rtmpUrls: [""],
+        rtmpURLs: [""],
         record: true
     };
     try {


### PR DESCRIPTION
According to this portion in the document, it should be `rtmpURLs` https://www.100ms.live/docs/api-reference/javascript/v2/interfaces/RTMPRecordingConfig