### PR TITLE
Fixed spelling mistakes

### DIFF
--- a/docs/javascript/v2/features/chat.mdx
+++ b/docs/javascript/v2/features/chat.mdx
@@ -77,7 +77,7 @@ import {
 
 function Chat() {
     // use only the selectors that are required for the corresponding UI
-    const allMessages = useHMSStore(selectMessages); // get all messages
+    const allMessages = useHMSStore(selectHMSMessages); // get all messages
     const broadcastMessages = useHMSStore(selectBroadcastMessages); // get all broadcasted messages
     const groupMessagesByRole = useHMSStore(selectMessagesByRole('host')); // get conversation with the host role
     const directMessages = useHMSStore(selectMessagesByPeerID(peer.id)); // get private conversation with peer

--- a/docs/javascript/v2/features/chat.mdx
+++ b/docs/javascript/v2/features/chat.mdx
@@ -78,7 +78,7 @@ import {
 function Chat() {
     // use only the selectors that are required for the corresponding UI
     const allMessages = useHMSStore(selectMessages); // get all messages
-    const brodacastMessages = useHMSStore(selectBroadcastMessages); // get all broadcasted messages
+    const broadcastMessages = useHMSStore(selectBroadcastMessages); // get all broadcasted messages
     const groupMessagesByRole = useHMSStore(selectMessagesByRole('host')); // get conversation with the host role
     const directMessages = useHMSStore(selectMessagesByPeerID(peer.id)); // get private conversation with peer
 


### PR DESCRIPTION
https://github.com/100mslive/100ms-docs/blob/main/docs/javascript/v2/features/chat.mdx

Problem 1:
In React to get the broadcast messages, spelling mistake:
brodacast should be broadcast
(Search brodacast and you will get the error)

- Fixed this

Problem 2:
Check the line above the "brodacast"
the parameter of selecting all messages - selectMessages should be selectHMSMessages

- Fixed this