### PR TITLE
Remove "refer these links" from 404 page

### DIFF
--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -62,20 +62,11 @@ const NotFound = () => {
                         }}>
                         {router.asPath}
                     </Text>
-                    <Text
-                        variant="h6"
-                        css={{
-                            color: '$textHighEmp',
-                            my: '$12',
-                            textAlign: 'center'
-                        }}>
-                        Refer these links:
-                    </Text>
                     <Flex
                         justify="center"
                         css={{
                             gap: '$6',
-                            mt: '$8',
+                            mt: '$18',
                             flexWrap: 'wrap',
                             w: '100%',
                             maxWidth: '600px',


### PR DESCRIPTION
Before:

<img width="1792" alt="image" src="https://user-images.githubusercontent.com/57426646/220007275-61d2f983-ae43-42c2-9825-5b7edd936bc6.png">


After:

<img width="1792" alt="image" src="https://user-images.githubusercontent.com/57426646/220007222-e79f7de2-1922-4a24-80b2-8f38eae37596.png">
