### PR TITLE
DOCS-118 Fix docs platform selection

### DIFF
--- a/components/ChipDropDown.tsx
+++ b/components/ChipDropDown.tsx
@@ -33,14 +33,19 @@ const ChipDropDown = ({
 
     useEffect(() => {
         if (typeof window !== 'undefined') {
-            let setFilter = false;
-            updatedMenuItem.forEach((plat) => {
-                if (!setFilter && plat && window.location.pathname.includes(plat.key)) {
-                    setPlatformFilter(plat.name);
-                    setFilter = true;
-                }
-            });
+            const url = localStorage.getItem('platformFilterSetAt') || '';
+            if (url !== location.href.toString()) {
+                localStorage.setItem('platformFilterSetAt', location.href.toString());
+                let setFilter = false;
+                updatedMenuItem.forEach((plat) => {
+                    if (!setFilter && plat && window.location.pathname.includes(plat.key)) {
+                        setPlatformFilter(plat.name);
+                        setFilter = true;
+                    }
+                });
+            }
         }
+        return () => console.log('Unmounting dropdown');
     }, []);
 
     return (

--- a/components/ChipDropDown.tsx
+++ b/components/ChipDropDown.tsx
@@ -45,7 +45,6 @@ const ChipDropDown = ({
                 });
             }
         }
-        return () => console.log('Unmounting dropdown');
     }, []);
 
     return (

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -412,7 +412,7 @@ const Sidebar: React.FC<Props> = ({
                         {nav
                             ? Object.entries(nav).map(([key, children], index) => (
                                   <SidebarSection
-                                      key={`${key}-${index}`}
+                                      key={`${key}-${index}-section`}
                                       value={key}
                                       index={index}
                                       nested={false}>

--- a/components/SidebarSection.tsx
+++ b/components/SidebarSection.tsx
@@ -121,14 +121,14 @@ const SidebarSection: React.FC<Props> = ({ value: key, index, children, nested =
                 {Object.entries(children as {}).map(([_, route]: [string, any], i: number) =>
                     Object.prototype.hasOwnProperty.call(route, 'title') ? (
                         <SidebarItem
-                            key={`${route.title}-${i}`}
+                            key={`${route.title}-${i}-item`}
                             asPath={asPath}
                             route={route}
                             activeItem={activeItem}
                             index={index}
                         />
                     ) : (
-                        <SidebarSection key={`${route.title}-${i}`} index={index} value={_} nested>
+                        <SidebarSection key={`${route.title}-${i}-title`} index={index} value={_} nested>
                             {route}
                         </SidebarSection>
                     )


### PR DESCRIPTION
The parent of dropdown component was re-rendering too many times, added a check to ensure the platform based on URL is set once on a particular page.

Misc fixes - updated keys for sidebar items and sections, had matching keys for some folders and files