### PR TITLE
2.6.8 release

### DIFF
--- a/docs/android/v2/changelog/release-notes.mdx
+++ b/docs/android/v2/changelog/release-notes.mdx
@@ -6,7 +6,7 @@ description: Release Notes for 100ms Android SDK
 ## v2.6.8 - 2023-06-28
 
 ### Added
-- Added an option to prevent muting of local audio track during VoIP call rings. This is available via `HMSAudioTrackSettings` builder `setPhoneCallMuteState()` method.
+- Added option to NOT mute when phone is in ringing state. Using this also means that SDK cannot mute local peer on receiving a VoIP phone call
 
 ## v2.6.7 - 2023-06-2
 

--- a/docs/android/v2/changelog/release-notes.mdx
+++ b/docs/android/v2/changelog/release-notes.mdx
@@ -6,7 +6,7 @@ description: Release Notes for 100ms Android SDK
 ## v2.6.8 - 2023-06-28
 
 ### Added
-- Added an option to prevent muting local audio track during VoIP call rings. This is available via `HMSAudioTrackSettings` builder `setPhoneCallMuteState()` method.
+- Added an option to prevent muting of local audio track during VoIP call rings. This is available via `HMSAudioTrackSettings` builder `setPhoneCallMuteState()` method.
 
 ## v2.6.7 - 2023-06-2
 

--- a/docs/android/v2/changelog/release-notes.mdx
+++ b/docs/android/v2/changelog/release-notes.mdx
@@ -3,6 +3,11 @@ title: Release Notes
 nav: 4
 description: Release Notes for 100ms Android SDK
 ---
+## v2.6.8 - 2023-06-28
+
+### Added
+- Added an option to prevent muting of VoIP calls when it rings. This is available via `HMSAudioTrackSettings` builder `setPhoneCallMuteState()` method.
+
 ## v2.6.7 - 2023-06-2
 
 ### Added

--- a/docs/android/v2/changelog/release-notes.mdx
+++ b/docs/android/v2/changelog/release-notes.mdx
@@ -6,7 +6,7 @@ description: Release Notes for 100ms Android SDK
 ## v2.6.8 - 2023-06-28
 
 ### Added
-- Added an option to prevent muting of VoIP calls when it rings. This is available via `HMSAudioTrackSettings` builder `setPhoneCallMuteState()` method.
+- Added an option to prevent muting local audio track during VoIP call rings. This is available via `HMSAudioTrackSettings` builder `setPhoneCallMuteState()` method.
 
 ## v2.6.7 - 2023-06-2
 


### PR DESCRIPTION
## v2.6.8 - 2023-06-28

### Added
- Added option to NOT mute when phone is in ringing state. Using this also means that SDK cannot mute local peer on receiving a VoIP phone call