### PR TITLE
Update components

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ Here's some of them added and can be easily added:
 </Note>
 ```
 
+Types available: `success`,`warning`,`error`, `white`
+
 ---
 
 #### 2. Code
@@ -181,7 +183,7 @@ All CSS Variables prefixed with `token` control the Syntax Highlighting.
 
 ## #️⃣ Viewing updated release versions on local before pushing changes
 
-- To view the updated release version on local after adding changelog, run the following command before starting the local server:
+-   To view the updated release version on local after adding changelog, run the following command before starting the local server:
     -   `yarn updatereleases`
     -   `yarn dev`
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Here's some of them added and can be easily added:
 
 #### 1. Note Component
 
--   You can easily use this by using `> blockquote` it will have a default type of `'success'`
+-   You can easily use this by using `> blockquote` it will have a default type of `white`
 -   To use other types write in this way
 
 ```jsx

--- a/components/Callout.tsx
+++ b/components/Callout.tsx
@@ -3,10 +3,11 @@ import { Flex, Text, Box } from '@100mslive/react-ui';
 
 const Callout = ({ title, icon, children }) => (
     <Flex
+        className="callout"
         direction="column"
         justify="between"
         css={{
-            borderRadius: '$3',
+            borderRadius: '0.5rem',
             border: '1px solid',
             borderColor: '$surfaceLighter',
             width: '100%',

--- a/components/Note.tsx
+++ b/components/Note.tsx
@@ -10,7 +10,7 @@ interface Props {
 // Error: red
 // White: white
 
-const Note: React.FC<Props> = ({ type = 'success', title = '', children }) => {
+const Note: React.FC<Props> = ({ type = 'white', title = '', children }) => {
     const resolveColor = () => `var(--${type})`;
     return (
         <div className="note">

--- a/components/Note.tsx
+++ b/components/Note.tsx
@@ -20,6 +20,7 @@ const Note: React.FC<Props> = ({ type = 'success', title = '', children }) => {
                         fontWeight: '500',
                         fontSize: '13px',
                         paddingBottom: '4px',
+                        lineHeight: '24px',
                         color: resolveColor()
                     }}>
                     {title}
@@ -31,9 +32,7 @@ const Note: React.FC<Props> = ({ type = 'success', title = '', children }) => {
                     padding-left: 20px;
                     background: var(--docs_bg_card);
                     margin: 24px 0;
-                    border-radius: var(--docs_border_radius_s);
-                    border 1px solid var(--docs_border_strong);
-                    border-left: 8px solid ${resolveColor()};
+                    border-left: 4px solid ${resolveColor()};
                 }
             `}</style>
         </div>

--- a/components/Note.tsx
+++ b/components/Note.tsx
@@ -1,18 +1,34 @@
 import React from 'react';
 
 interface Props {
-    type: 'warning' | 'success' | 'error';
+    type: 'warning' | 'success' | 'error' | 'white';
+    title?: string;
 }
 
-const Note: React.FC<Props> = ({ type = 'success', children }) => {
+// Warning: yellow
+// Success: Green
+// Error: red
+// White: white
+
+const Note: React.FC<Props> = ({ type = 'success', title = '', children }) => {
     const resolveColor = () => `var(--${type})`;
     return (
         <div className="note">
+            {title ? (
+                <span
+                    style={{
+                        fontWeight: '500',
+                        fontSize: '13px',
+                        paddingBottom: '4px',
+                        color: resolveColor()
+                    }}>
+                    {title}
+                </span>
+            ) : null}
             {children}
             <style jsx>{`
                 div {
-                    padding: 16px;
-                    padding-left: 24px;
+                    padding-left: 20px;
                     background: var(--docs_bg_card);
                     margin: 24px 0;
                     border-radius: var(--docs_border_radius_s);

--- a/components/Note.tsx
+++ b/components/Note.tsx
@@ -6,7 +6,7 @@ interface Props {
 }
 
 // Warning: yellow
-// Success: Green
+// Success: green
 // Error: red
 // White: white
 

--- a/docs/android/v2/how-to-guides/interact-with-room/room/session-store.mdx
+++ b/docs/android/v2/how-to-guides/interact-with-room/room/session-store.mdx
@@ -7,8 +7,7 @@ Session store is a shared realtime key-value store that is accessible by everyon
 
 The session store persists throughout the session and is cleared when the last peer leaves the room.
 
-<Note>
-💡 Session Store vs Peer Metadata
+<Note title="💡 Session Store vs Peer Metadata">
 
 While peer metadata is associated with individual peers and each peer can have their own metadata, session store remains the same for every peer in the room.
 
@@ -31,7 +30,6 @@ fun updateSessionStore(data: Any?, key : String, hmsActionResultListener: HMSAct
     hmsSessionStore.set(data, key, hmsActionResultListener)
 }
 ```
-
 
 </Tab>
 
@@ -73,11 +71,11 @@ sessionStore.addKeyChangeListener(listOf("time","cat","cats"), object : HMSKeyCh
                             val cat : Cat = Gson().fromJson(value as JsonElement, Cat::class.java)
                     }
                     // Lists of objects
-                    "cats" -> { 
+                    "cats" -> {
                         val type = TypeToken.getParameterized(List::class.java, Cat::class.java).type
 
                         if(value !=null && key == catKey)
-                            val cats: List<Cats> = Gson().fromJson(value, type)                        
+                            val cats: List<Cats> = Gson().fromJson(value, type)
                      }
                 }
             }
@@ -88,7 +86,6 @@ sessionStore.addKeyChangeListener(listOf("time","cat","cats"), object : HMSKeyCh
             }
         )
 ```
-
 
 </Tab>
 
@@ -152,7 +149,6 @@ Use the `get(key : String, listener: HMSSessionMetadataListener)` API if your ap
 
 <Tab id='sessionstoresingle-0'>
 
-
 ```kotlin
 sessionStore.get("mykey", object : HMSSessionMetadataListener {
     override fun onSuccess(sessionMetadata: JsonElement?) {
@@ -188,6 +184,7 @@ sessionStore.get("mykey",new  HMSSessionMetadataListener(){
 
 });
 ```
+
 </Tab>
 
 ## Limitations and workarounds in Alpha release
@@ -199,6 +196,6 @@ sessionStore.get("mykey",new  HMSSessionMetadataListener(){
 
 ## Limits
 
-- Max payload size for data can be 1KB.
-- Maximum 100 keys are supported with 64KB limit applied to all keys combined.
-- Metadata size for 64 KB also include the key size.
+-   Max payload size for data can be 1KB.
+-   Maximum 100 keys are supported with 64KB limit applied to all keys combined.
+-   Metadata size for 64 KB also include the key size.

--- a/knip.js
+++ b/knip.js
@@ -1,1 +1,0 @@
-const config = {entry:['pages/index.tsx'], project:['.*\.tsx$']}; export default config;

--- a/knip.js
+++ b/knip.js
@@ -1,0 +1,1 @@
+const config = {entry:['pages/index.tsx'], project:['.*\.tsx$']}; export default config;

--- a/styles/spacing.css
+++ b/styles/spacing.css
@@ -309,6 +309,7 @@ article .note+p {
 
 article .note p {
     margin-top: 0 !important;
+    font-size: 13px;
 }
 
 /* List Spacing */

--- a/styles/spacing.css
+++ b/styles/spacing.css
@@ -578,6 +578,10 @@ ul.dropdown-options {
     }
 }
 
+.callout .callout {
+    margin-top: 8px;
+}
+
 /* Classes for special cases */
 
 

--- a/styles/theme.css
+++ b/styles/theme.css
@@ -73,12 +73,12 @@ to decide colors
     --token_inserted: rgba(38, 166, 155, 0.5);
     --token_comment: var(--gray10);
 
-    --success: var(--primary_light);
+    --twin_green: #14B881;
+    --success: #36B37E;
     --white: #FFF;
     --warning: #f5a623;
-    --error: #CC525F;
     --alert_error: #CC525F;
-    --twin_green: #14B881;
+    --error: var(--alert_error);
 
     --surface_default: #13161B;
 

--- a/styles/theme.css
+++ b/styles/theme.css
@@ -74,7 +74,9 @@ to decide colors
     --token_comment: var(--gray10);
 
     --success: var(--primary_light);
+    --white: #FFF;
     --warning: #f5a623;
+    --error: #CC525F;
     --alert_error: #CC525F;
     --twin_green: #14B881;
 


### PR DESCRIPTION
Updated callout: https://100ms.atlassian.net/browse/SS-3423

Note variants: https://100ms.atlassian.net/browse/SS-3422

Variant to color mapping:
- warning: yellow
- success: green 
- error: red 
- white: white (default)

Usage: new optional `title` prop

```
<Note title="💡 Session Store vs Peer Metadata">
While peer metadata is associated with individual peers and each peer can have their own metadata, session store remains the same for every peer in the room.
</Note>
```
<img width="909" alt="image" src="https://github.com/100mslive/100ms-docs/assets/57426646/67dfe04e-a429-4cf3-ad54-25cb6c4c2c8f">
