### PR TITLE
Fix code formatting in Prebuilt Quickstart

### DIFF
--- a/docs/prebuilt/v2/prebuilt/quickstart.mdx
+++ b/docs/prebuilt/v2/prebuilt/quickstart.mdx
@@ -147,15 +147,15 @@ Sample code snippet to embed Prebuilt component. Head over for a step by step gu
 ```jsx section=SampleCode sectionIndex=0 tab=React
 
 // import HMSPrebuilt component from Roomkit package
-import { HMSPrebuilt } from '@100mslive/roomkit-react';
+import { HMSPrebuilt } from "@100mslive/roomkit-react";
 
 // add pre-built component
 function App() {
-return (
-<div style={{ height: "100vh" }}>
-<HMSPrebuilt roomCode="<room-code>" />
-</div>
-);
+  return (
+    <div style={{ height: "100vh" }}>
+      <HMSPrebuilt roomCode="<room-code>" />
+    </div>
+  );
 }
 
 export default App;

--- a/docs/prebuilt/v2/prebuilt/quickstart.mdx
+++ b/docs/prebuilt/v2/prebuilt/quickstart.mdx
@@ -185,9 +185,9 @@ import SwiftUI
 import HMSRoomKit
 
 struct ContentView: View {
-var body: some View {
-HMSPrebuiltView(roomCode: /_pass room code as string here_/)
-}
+    var body: some View {
+        HMSPrebuiltView(roomCode: /_pass room code as string here_/)
+    }
 }
 
 ````


### PR DESCRIPTION
Fixes the code formatting for the React and iOS snippets in the 'Embedding HMSPrebuilt component' tabs.

<img width="816" alt="Screenshot 2024-04-23 at 11 24 52 AM" src="https://github.com/100mslive/100ms-docs/assets/53579386/f122c4ba-250d-417e-857d-289a3c4adffa">
<img width="801" alt="Screenshot 2024-04-23 at 11 24 58 AM" src="https://github.com/100mslive/100ms-docs/assets/53579386/92befea5-a90e-40c9-982c-ed0301daf596">

