### PR TITLE
Adds a subtitle component

### DIFF
--- a/components/MDXComponents.tsx
+++ b/components/MDXComponents.tsx
@@ -27,6 +27,7 @@ import { PortraitImage } from './PortraitImage';
 import { CollapsibleRoot, CollapsiblePreview, CollapsibleContent } from './CollapsibleSection';
 import { CollapsibleStep } from './CollapsibleStep';
 import SuggestedBlogs from './SuggestedBlogs';
+import Subtitle from './Subtitle';
 
 const CodeCustom = (props: any) => <Code {...props}>{props.children}</Code>;
 
@@ -114,7 +115,8 @@ const MDXComponents = {
     CollapsiblePreview,
     CollapsibleContent,
     CollapsibleStep,
-    DynamicIcon
+    DynamicIcon,
+    Subtitle
 };
 
 export default MDXComponents;

--- a/components/Subtitle.tsx
+++ b/components/Subtitle.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Text } from '@100mslive/react-ui';
 
 const Subtitle = ({ content }) => (
-    <Text as="p" css={{ color: 'var(--gray9)', fontSize: '18px' }}>
+    <Text as="p" css={{ color: 'var(--secondary_default)', fontSize: '18px' }}>
         {content}
     </Text>
 );

--- a/components/Subtitle.tsx
+++ b/components/Subtitle.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { Text } from '@100mslive/react-ui';
+
+const Subtitle = ({ subtitle }) => (
+    <Text as="p" css={{ color: 'var(--gray9)', fontSize: '18px' }}>
+        {subtitle}
+    </Text>
+);
+
+export default Subtitle;

--- a/components/Subtitle.tsx
+++ b/components/Subtitle.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { Text } from '@100mslive/react-ui';
 
-const Subtitle = ({ subtitle }) => (
+const Subtitle = ({ content }) => (
     <Text as="p" css={{ color: 'var(--gray9)', fontSize: '18px' }}>
-        {subtitle}
+        {content}
     </Text>
 );
 


### PR DESCRIPTION
For headings we use H1, H2, H3 etc, but the new docs require a subtitle component that can be added as:

```
<Subtitle content="" />
```
Example:
<img width="550" alt="Screenshot 2024-06-04 at 2 10 20 PM" src="https://github.com/100mslive/100ms-docs/assets/53579386/c101f190-76bd-49c3-9b95-c5870260a7a1">

