### PR TITLE
Adds a subtitle to use in docs

### DIFF
--- a/pages/[...slug].tsx
+++ b/pages/[...slug].tsx
@@ -44,6 +44,7 @@ export interface PaginationType {
 interface Props {
     frontMatter: {
         title: string;
+        subtitle: string;
         nav: number;
     };
     nav: Record<string, Record<string, NavRoute>>;
@@ -133,6 +134,11 @@ const DocSlugs = ({ source, frontMatter, pagination, showToc = true }: Props) =>
                     paddingBottom: '80px'
                 }}>
                 <h1>{frontMatter.title}</h1>
+                {frontMatter.subtitle ? (
+                    <h3 className="subtitle">{frontMatter.subtitle}</h3>
+                ) : (
+                    <></>
+                )}
                 <MDXProvider components={components}>
                     <Component />
                 </MDXProvider>

--- a/pages/[...slug].tsx
+++ b/pages/[...slug].tsx
@@ -44,7 +44,7 @@ export interface PaginationType {
 interface Props {
     frontMatter: {
         title: string;
-        subtitle: string;
+        subtitle?: string;
         nav: number;
     };
     nav: Record<string, Record<string, NavRoute>>;

--- a/styles/theme.css
+++ b/styles/theme.css
@@ -465,6 +465,13 @@ code:not(.ch-code-scroll-parent) {
     font-weight: 600;
 }
 
+.subtitle {
+    color: #a0a0a0;
+    font-weight: 400;
+    font-size: 1.25em;
+    margin-top: 5px;
+}
+
 pre code:not(.ch-code-scroll-parent) {
     border: none;
     border-radius: 0;


### PR DESCRIPTION
Can now add a subtile under the title at the top of `.mdx` file as below:

```
--- 
title: Video Conferencing 
subtitle: Enable live video communication within your app 
nav: 1.02 
---
```

Output:
<img width="783" alt="Screenshot 2024-06-06 at 12 09 16 PM" src="https://github.com/100mslive/100ms-docs/assets/53579386/9cf25f64-43bf-4874-a4d6-d2bfcce5ff45">
