### PR TITLE
Update release notes for v2.9.81

### DIFF
--- a/docs/android/v2/release-notes/release-notes.mdx
+++ b/docs/android/v2/release-notes/release-notes.mdx
@@ -19,6 +19,10 @@ import AndroidPrebuiltVersionShield from '@/common/android-prebuilt-version-shie
 | live.100ms:virtual-background: |<AndroidSdkVersionShield />|
 | live.100ms:hms-noise-cancellation-android: | <AndroidSdkVersionShield /> |
 
+## v2.9.81 - 2026-03-30
+### Fixed
+*  Fix for crash caused by duplicate TelephonyCallback registration during reconnection.
+
 ## v2.9.80 - 2026-02-10
 ### Fixed
 *  Bug fix for image capture callback reliability during camera operations.


### PR DESCRIPTION
Add a new entry for version 2.9.81, detailing a fix for a crash caused by duplicate TelephonyCallback registration during reconnection.