### PR TITLE
docs: add 0.13.3 release notes and translation docs

### DIFF
--- a/docs/javascript/v2/how-to-guides/set-up-video-conferencing/captions.mdx
+++ b/docs/javascript/v2/how-to-guides/set-up-video-conferencing/captions.mdx
@@ -187,3 +187,134 @@ try {
     console.error('Failed to stop captions:', err);
 }
 ```
+
+## Translation
+
+Translation enables each role to receive captions translated into their configured language. Translation must be enabled in the template policy with per-role language mappings (e.g., `host → es`, `guest → fr`).
+
+> Translation requires SDK version 0.13.3 or above and the translation feature enabled in your template's transcription destination.
+
+### Start captions with translation
+
+Pass `translation` when starting transcription to enable translation from the start:
+
+<Tabs id="captions-translation-start" items={['JavaScript', 'React']} />
+
+<Tab id='captions-translation-start-0'>
+
+```js
+import { HMSTranscriptionMode } from '@100mslive/hms-video-store';
+
+await hmsActions.startTranscription({
+    mode: HMSTranscriptionMode.CAPTION,
+    translation: {
+        enabled: true,
+    },
+});
+```
+
+You can also override the template's role-language mapping at start time:
+
+```js
+await hmsActions.startTranscription({
+    mode: HMSTranscriptionMode.CAPTION,
+    translation: {
+        enabled: true,
+        roleLanguages: { host: 'es', guest: 'fr' },
+    },
+});
+```
+
+</Tab>
+
+<Tab id='captions-translation-start-1'>
+
+```jsx
+import { HMSTranscriptionMode, useHMSActions } from '@100mslive/react-sdk';
+
+function StartCaptionsWithTranslation() {
+    const hmsActions = useHMSActions();
+
+    const startWithTranslation = async () => {
+        await hmsActions.startTranscription({
+            mode: HMSTranscriptionMode.CAPTION,
+            translation: { enabled: true },
+        });
+    };
+
+    return <button onClick={startWithTranslation}>Start Captions + Translation</button>;
+}
+```
+
+</Tab>
+
+### Toggle translation mid-session
+
+Use `hmsActions.updateTranscriptionConfig()` to enable or disable translation while captions are already running:
+
+```js
+// Enable translation mid-call
+await hmsActions.updateTranscriptionConfig({
+    translation: { enabled: true },
+});
+
+// Disable translation (captions continue in original language)
+await hmsActions.updateTranscriptionConfig({
+    translation: { enabled: false },
+});
+
+// Change the transcription input language
+await hmsActions.updateTranscriptionConfig({
+    language: 'hi',
+});
+```
+
+### Check translation state
+
+Use the `selectTranslationState` selector to read the current translation state:
+
+<Tabs id="captions-translation-check" items={['JavaScript', 'React']} />
+
+<Tab id='captions-translation-check-0'>
+
+```js
+import { selectTranslationState } from '@100mslive/hms-video-store';
+
+const translationState = hmsStore.getState(selectTranslationState);
+// { available: true, enabled: true, roleLanguages: { host: 'es', guest: 'fr' } }
+
+// Subscribe to changes
+hmsStore.subscribe((state) => {
+    console.log('Translation enabled:', state.enabled);
+    console.log('Role languages:', state.roleLanguages);
+}, selectTranslationState);
+```
+
+</Tab>
+
+<Tab id='captions-translation-check-1'>
+
+```jsx
+import { selectTranslationState, useHMSStore } from '@100mslive/react-sdk';
+
+function TranslationStatus() {
+    const { available, enabled, roleLanguages } = useHMSStore(selectTranslationState);
+
+    if (!available) return <span>Translation not configured</span>;
+
+    return (
+        <div>
+            <span>Translation: {enabled ? 'ON' : 'OFF'}</span>
+            {roleLanguages && (
+                <ul>
+                    {Object.entries(roleLanguages).map(([role, lang]) => (
+                        <li key={role}>{role}: {lang}</li>
+                    ))}
+                </ul>
+            )}
+        </div>
+    );
+}
+```
+
+</Tab>

--- a/docs/javascript/v2/release-notes/release-notes.mdx
+++ b/docs/javascript/v2/release-notes/release-notes.mdx
@@ -20,7 +20,7 @@ Released: `@100mslive/hms-video-store@0.13.3`, `@100mslive/react-sdk@0.11.3`, `@
 
 ### Added:
 
--   Translation support for live transcription — enables per-role language translation for captions
+-   [Translation support for live transcription](/javascript/v2/how-to-guides/set-up-video-conferencing/captions#translation) — enables per-role language translation for captions
 
 ### Fixed:
 

--- a/docs/javascript/v2/release-notes/release-notes.mdx
+++ b/docs/javascript/v2/release-notes/release-notes.mdx
@@ -14,6 +14,18 @@ description: Release Notes for 100ms.live JavaScript SDK
 | @100mslive/hms-noise-cancellation | [![npm version](https://badge.fury.io/js/%40100mslive%2Fhms-noise-cancellation.svg)](https://badge.fury.io/js/%40100mslive%2Fhms-noise-cancellation) |
 | @100mslive/hms-virtual-background | [![npm version](https://badge.fury.io/js/%40100mslive%2Fhms-virtual-background.svg)](https://badge.fury.io/js/%40100mslive%2Fhms-virtual-background) |
 
+## 2026-04-15
+
+Released: `@100mslive/hms-video-store@0.13.3`, `@100mslive/react-sdk@0.11.3`, `@100mslive/hls-player@0.4.3`, `@100mslive/roomkit-react@0.4.3`
+
+### Added:
+
+-   Translation support for live transcription — enables per-role language translation for captions
+
+### Fixed:
+
+-   Updated CDN endpoint for Effects SDK assets and noise cancellation plugin
+
 ## 2026-02-10
 
 Released: `@100mslive/hms-video-store@0.13.2`, `@100mslive/react-sdk@0.11.2`, `@100mslive/hls-player@0.4.2`, `@100mslive/roomkit-react@0.4.2`, `@100mslive/hms-whiteboard@0.1.2`


### PR DESCRIPTION
## Summary
- Add release notes for web SDK 0.13.3 (2026-04-15)
- Add Translation section to captions documentation with:
  - Start captions with translation enabled
  - Toggle translation mid-session via `updateTranscriptionConfig`
  - Check translation state with `selectTranslationState` selector
  - Both JavaScript and React examples

## Test plan
- [ ] Verify release notes render correctly
- [ ] Verify translation section renders with proper tabs
- [ ] Check code examples are syntactically correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)