### PR TITLE
fix: update algolia keys

### DIFF
--- a/lib/algolia/getRecords.js
+++ b/lib/algolia/getRecords.js
@@ -14,7 +14,7 @@ const {
 
 async function updateIndex() {
     const appId = process.env.NEXT_PUBLIC_ALGOLIA_APP_ID;
-    const adminKey = process.env.NEXT_PUBLIC_ALGOLIA_ADMIN_API_KEY;
+    const adminKey = process.env.ALGOLIA_ADMIN_API_KEY;
     const algoliaIndex = process.env.NEXT_PUBLIC_ALGOLIA_INDEX;
 
     if (appId && adminKey && algoliaIndex) {


### PR DESCRIPTION
## Summary
- Rename `NEXT_PUBLIC_ALGOLIA_ADMIN_API_KEY` → `ALGOLIA_ADMIN_API_KEY` in `lib/algolia/getRecords.js`.
- The `NEXT_PUBLIC_` prefix causes Next.js to inline env vars into the client JS bundle. The Algolia admin key grants write access to the search index and must stay server-only. The variable is only read in two server-side contexts (the build-time `searchIndex.js` script and the `/api/updateAlgolia` route), so the prefix was never needed.

## Action required before merge
The env var must be renamed in the deployment environment (Vercel project settings, CI secrets, local `.env` files) from `NEXT_PUBLIC_ALGOLIA_ADMIN_API_KEY` to `ALGOLIA_ADMIN_API_KEY`. Until then, the `if (appId && adminKey && algoliaIndex)` guard in `updateIndex()` will fail silently and the search index will not be updated on build.

As a follow-up, the existing admin key should be **rotated** in Algolia since it has been inlined into previously deployed client bundles.

## Test plan
- [ ] Update the env var name in Vercel (or equivalent) before merge.
- [ ] After merge, confirm `yarn build` logs show the Algolia index update running (not the silent no-op branch).
- [ ] Confirm search still works on the deployed site.
- [ ] Rotate the Algolia admin key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)