### PR TITLE
docs: add 0.13.4 web SDK release notes

### DIFF
--- a/docs/javascript/v2/how-to-guides/extend-capabilities/plugins/krisp-noise-cancellation.mdx
+++ b/docs/javascript/v2/how-to-guides/extend-capabilities/plugins/krisp-noise-cancellation.mdx
@@ -40,8 +40,26 @@ toggle(): void;
 // whether the noise cancellation is currently enabled
 isEnabled(): boolean | undefined;
 
+// Sets the noise suppression strength on the active filter node.
+// The prebuilt suppression-level slider drives values from 0 to 100.
+setNoiseSuppressionLevel(level: number): void;
+
 stop(): void; 
 
+```
+
+### Adjusting the noise suppression level
+
+`setNoiseSuppressionLevel(level: number)` forwards the provided level to the underlying Krisp filter node. The prebuilt Suppression Level slider (in `@100mslive/roomkit-react`) drives this method with integer values from `0` to `100`. Calling it before the plugin has been added to the audio track (i.e. before a filter node exists) is a no-op; apply the level after the plugin is active.
+
+```js
+import { HMSKrispPlugin } from '@100mslive/hms-noise-cancellation';
+
+const plugin = new HMSKrispPlugin();
+await hmsActions.addPluginToAudioTrack(plugin);
+
+// Reduce suppression strength to 60% once the plugin is active
+plugin.setNoiseSuppressionLevel(60);
 ```
 
 Checking if noise cancellation is enabled for the room. Please reach out to us to get this enabled for you.

--- a/docs/javascript/v2/release-notes/release-notes.mdx
+++ b/docs/javascript/v2/release-notes/release-notes.mdx
@@ -21,7 +21,7 @@ Released: `@100mslive/hms-video-store@0.13.4`, `@100mslive/react-sdk@0.11.4`, `@
 ### Added:
 
 -   Added support for noise suppression level for [`HMSKrispPlugin`](/javascript/v2/how-to-guides/extend-capabilities/plugins/krisp-noise-cancellation#adjusting-the-noise-suppression-level)
--   Roomkit Prebuilt: Noise suppression level slider in the prebuilt settings — let's users tune how aggressively background noise is filtered
+-   Roomkit Prebuilt: Noise suppression level slider in the prebuilt while enabling noise cancellation — let's users tune how aggressively background noise is filtered
 
 ### Fixed:
 

--- a/docs/javascript/v2/release-notes/release-notes.mdx
+++ b/docs/javascript/v2/release-notes/release-notes.mdx
@@ -20,11 +20,12 @@ Released: `@100mslive/hms-video-store@0.13.4`, `@100mslive/react-sdk@0.11.4`, `@
 
 ### Added:
 
--   Noise suppression level slider in the prebuilt settings — lets users tune how aggressively background noise is filtered
+-   Added support for noise suppression level for [`HMSKrispPlugin`](/javascript/v2/how-to-guides/extend-capabilities/plugins/krisp-noise-cancellation#adjusting-the-noise-suppression-level)
+-   Roomkit Prebuilt: Noise suppression level slider in the prebuilt settings — let's users tune how aggressively background noise is filtered
 
 ### Fixed:
 
--   Publish Bitrate metric no longer counts ICE / RTCP / BWE traffic, giving a more accurate view of actual media send rate
+-   Roomkit Prebuilt: Stats for Nerds localPeer `Publish Bitrate` metric no longer counts ICE / RTCP / BWE traffic, giving a more accurate view of actual media send rate
 
 ## 2026-04-15
 

--- a/docs/javascript/v2/release-notes/release-notes.mdx
+++ b/docs/javascript/v2/release-notes/release-notes.mdx
@@ -14,6 +14,18 @@ description: Release Notes for 100ms.live JavaScript SDK
 | @100mslive/hms-noise-cancellation | [![npm version](https://badge.fury.io/js/%40100mslive%2Fhms-noise-cancellation.svg)](https://badge.fury.io/js/%40100mslive%2Fhms-noise-cancellation) |
 | @100mslive/hms-virtual-background | [![npm version](https://badge.fury.io/js/%40100mslive%2Fhms-virtual-background.svg)](https://badge.fury.io/js/%40100mslive%2Fhms-virtual-background) |
 
+## 2026-04-22
+
+Released: `@100mslive/hms-video-store@0.13.4`, `@100mslive/react-sdk@0.11.4`, `@100mslive/hls-player@0.4.4`, `@100mslive/roomkit-react@0.4.4`, `@100mslive/hms-noise-cancellation@0.1.0`
+
+### Added:
+
+-   Noise suppression level slider in the prebuilt settings — lets users tune how aggressively background noise is filtered
+
+### Fixed:
+
+-   Publish Bitrate metric no longer counts ICE / RTCP / BWE traffic, giving a more accurate view of actual media send rate
+
 ## 2026-04-15
 
 Released: `@100mslive/hms-video-store@0.13.3`, `@100mslive/react-sdk@0.11.3`, `@100mslive/hls-player@0.4.3`, `@100mslive/roomkit-react@0.4.3`


### PR DESCRIPTION
Captures the 22 Apr 2026 web SDK release ([release tag](https://github.com/100mslive/web-sdks/releases/tag/22Apr2026-0.13.4)) and documents the new `setNoiseSuppressionLevel` method on `@100mslive/hms-noise-cancellation` 0.1.0.

## What's in
- Release-notes entry for 2026-04-22 (hms-video-store 0.13.4, react-sdk 0.11.4, roomkit-react 0.4.4, hls-player 0.4.4, hms-noise-cancellation 0.1.0).
- `docs/javascript/v2/how-to-guides/extend-capabilities/plugins/krisp-noise-cancellation.mdx` — new `### Adjusting the noise suppression level` section with signature + copy-pasteable example (range 0–100, no-op before the filter node is active). Supersedes #2524.
- Cross-link from the release-notes entry to the new krisp section.

## Test plan
- [ ] Run the dev server, navigate to the release-notes page and the krisp noise-cancellation page, confirm both render and the cross-link resolves