### PR TITLE
LIV-273: update llms.txt for translation + Krisp suppression level + PR check for llms.txt update

### DIFF
--- a/.github/workflows/llms-txt-guard.yml
+++ b/.github/workflows/llms-txt-guard.yml
@@ -1,0 +1,49 @@
+name: llms.txt guard
+
+# Fails the PR if any docs/**/*.mdx file is added or removed without a
+# corresponding update to public/llms.txt. Modifications to existing MDX
+# files do not trigger the guard — only new pages or removed pages must
+# be reflected in the curated index.
+
+on:
+  pull_request:
+    branches:
+      - main
+      - qa
+    paths:
+      - 'docs/**/*.mdx'
+      - 'public/llms.txt'
+
+jobs:
+  check:
+    name: llms.txt updated for new docs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect new or removed MDX pages vs llms.txt changes
+        run: |
+          BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+
+          ADDED_REMOVED=$(git diff --name-only --diff-filter=AD "$BASE_SHA" "$HEAD_SHA" -- 'docs/**/*.mdx' || true)
+          LLMS_CHANGED=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" -- 'public/llms.txt' || true)
+
+          if [ -z "$ADDED_REMOVED" ]; then
+            echo "No MDX pages added or removed. Skipping."
+            exit 0
+          fi
+
+          echo "Added/removed MDX pages:"
+          echo "$ADDED_REMOVED"
+
+          if [ -z "$LLMS_CHANGED" ]; then
+            echo ""
+            echo "::error::New or removed docs/**/*.mdx pages detected but public/llms.txt was not updated."
+            echo "Add (or remove) a one-line entry in public/llms.txt for each new (or removed) page so LLM consumers stay in sync."
+            exit 1
+          fi
+
+          echo "public/llms.txt was updated. OK."

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -76,7 +76,7 @@ Prefer Prebuilt when speed of integration matters more than deep UI customizatio
 - [Chat](https://www.100ms.live/docs/javascript/v2/how-to-guides/set-up-video-conferencing/chat): Broadcast, group, and direct messaging over WebSocket.
 - [Screen Share](https://www.100ms.live/docs/javascript/v2/how-to-guides/set-up-video-conferencing/screen-share): Share screen, window, or browser tab.
 - [Simulcast / Select Video Quality](https://www.100ms.live/docs/javascript/v2/how-to-guides/set-up-video-conferencing/render-video/simulcast): Adaptive bitrate and manual quality selection.
-- [Live Captions (Closed Captions)](https://www.100ms.live/docs/javascript/v2/how-to-guides/set-up-video-conferencing/captions): Real-time speaker-labelled transcription and closed captions in WebRTC conferencing.
+- [Live Captions (Closed Captions)](https://www.100ms.live/docs/javascript/v2/how-to-guides/set-up-video-conferencing/captions): Real-time speaker-labelled transcription and closed captions in WebRTC conferencing. Supports per-role translation via template policy (e.g., `host → es`, `guest → fr`); can be toggled mid-session via `updateTranscriptionConfig()`. Translation requires SDK 0.13.3+.
 
 #### Interactive Features
 
@@ -86,7 +86,7 @@ Prefer Prebuilt when speed of integration matters more than deep UI customizatio
 #### Plugins & Extensions
 
 - [Whiteboard](https://www.100ms.live/docs/javascript/v2/how-to-guides/extend-capabilities/whiteboard): Real-time collaborative whiteboard.
-- [Krisp Noise Cancellation](https://www.100ms.live/docs/javascript/v2/how-to-guides/extend-capabilities/plugins/krisp-noise-cancellation): Background noise elimination plugin powered by Krisp.
+- [Krisp Noise Cancellation](https://www.100ms.live/docs/javascript/v2/how-to-guides/extend-capabilities/plugins/krisp-noise-cancellation): Background noise elimination plugin powered by Krisp. Suppression strength is adjustable at runtime via `setNoiseSuppressionLevel(0-100)` once the plugin is active (no-op before plugin attaches to the audio track); the prebuilt Suppression Level slider in `@100mslive/roomkit-react` drives this method.
 - [Virtual Background](https://www.100ms.live/docs/javascript/v2/how-to-guides/extend-capabilities/plugins/effects-virtual-background): Background blur and image replacement.
 
 #### Recording & Live Streaming
@@ -193,7 +193,7 @@ Prefer Prebuilt when speed of integration matters more than deep UI customizatio
 
 ### Live Transcription
 
-- [Live Captions for Conferencing](https://www.100ms.live/docs/javascript/v2/how-to-guides/set-up-video-conferencing/captions): Real-time speaker-labelled closed captions during WebRTC conferencing. Can be enabled/disabled at runtime per room. Currently English only.
+- [Live Captions for Conferencing](https://www.100ms.live/docs/javascript/v2/how-to-guides/set-up-video-conferencing/captions): Real-time speaker-labelled closed captions during WebRTC conferencing. Can be enabled/disabled at runtime per room. Supports per-role translation (each role receives captions in its configured target language) via template policy; toggleable mid-session via `updateTranscriptionConfig()`.
 - [Live Transcription in HLS](https://www.100ms.live/docs/server-side/v2/how-to-guides/live-transcription-hls): Auto-generated captions for HLS live streams.
 
 ### Post-Call


### PR DESCRIPTION
- Note per-role caption translation on the Live Captions entries (JS SDK and Transcription sections); replace stale "English only" remark.
- Note runtime-adjustable Krisp suppression via setNoiseSuppressionLevel on the Krisp Noise Cancellation entry.
- Add llms-txt-guard workflow that fails a PR when docs/**/*.mdx pages are added or removed without a corresponding public/llms.txt update, so the curated LLM index stays in sync with the docs surface.