### PR TITLE
docs(react-native): add 1.13.0 release notes

### DIFF
--- a/docs/react-native/v2/release-notes/release-notes.mdx
+++ b/docs/react-native/v2/release-notes/release-notes.mdx
@@ -11,6 +11,27 @@ nav: 4.1
 | @100mslive/react-native-hms          | [![npm](https://img.shields.io/npm/v/@100mslive/react-native-hms)](https://www.npmjs.com/package/@100mslive/react-native-hms)                   |
 | @100mslive/react-native-video-plugin | [![npm](https://img.shields.io/npm/v/@100mslive/react-native-video-plugin)](https://www.npmjs.com/package/@100mslive/react-native-video-plugin) |
 
+## 1.13.0 - 2026-04-30
+
+| Package                          | Version |
+| -------------------------------- | ------- |
+| @100mslive/react-native-room-kit | 1.3.1   |
+| @100mslive/react-native-hms      | 1.12.1  |
+
+### react-native-hms
+
+-   Fixed Android build failure on React Native 0.81+ with Kotlin 2.1.x (Expo SDK 54)
+
+    `:compileDebugKotlin` was failing with `Return type mismatch: expected MutableMap, actual Map` and `Unresolved reference: currentActivity`. Aligned `ViewManager` override return types with the Java parent (`Map` instead of `MutableMap`) and routed bare `currentActivity` accesses through `reactApplicationContext.currentActivity` for compatibility with stricter Kotlin 2.x type checking and newer React Native versions.
+
+### react-native-room-kit
+
+-   Bumped `@100mslive/react-native-hms` dependency to `1.12.1` so room-kit consumers automatically pick up the Android build fix above
+
+Uses Android SDK 2.9.78 & iOS SDK 1.17.0
+
+**Full Changelog**: [1.12.0...1.13.0](https://github.com/100mslive/100ms-react-native/compare/1.12.0...1.13.0)
+
 ## 1.12.0 - 2025-10-28
 
 | Package                              | Version |


### PR DESCRIPTION
## Summary

Adds release notes for the React Native SDK 1.13.0 release (published 2026-04-30).

This release contains a single fix to the Android build:

- `@100mslive/react-native-hms@1.12.1` — fixes `:compileDebugKotlin` failure on RN 0.81+ with Kotlin 2.1.x (Expo SDK 54). Affected `MutableMap`/`Map` return types in ViewManager overrides and bare `currentActivity` synthetic access.
- `@100mslive/react-native-room-kit@1.3.1` — bumps the hms dependency so room-kit consumers transitively pick up the fix.

GitHub release: https://github.com/100mslive/100ms-react-native/releases/tag/1.13.0