### PR TITLE
docs(react-native): add 2.0.0-alpha and 1.14.0 release notes

### DIFF
--- a/docs/react-native/v2/release-notes/release-notes.mdx
+++ b/docs/react-native/v2/release-notes/release-notes.mdx
@@ -31,9 +31,9 @@ npm install @100mslive/react-native-hms@alpha \
             @100mslive/react-native-video-plugin@alpha
 ```
 
-### Phase 0 (1.14.0) → Phase 1 (2.0.0-alpha)
+### Phase 0 (1.13.1) → Phase 1 (2.0.0-alpha)
 
-`1.14.0` made the SDK *survive* under new-arch apps via React Native's **Interop Layer** — a built-in shim that translates new-arch calls back to the old module API. The SDK's internals stayed old-arch; the Interop Layer did the translation. Useful, but you pay a translation cost on every call and can't reach the new-arch performance benefits.
+`1.13.1` made the SDK *survive* under new-arch apps via React Native's **Interop Layer** — a built-in shim that translates new-arch calls back to the old module API. The SDK's internals stayed old-arch; the Interop Layer did the translation. Useful, but you pay a translation cost on every call and can't reach the new-arch performance benefits.
 
 `2.0.0-alpha` replaces the shim with **native new-arch implementation**: TurboModule entry points, Fabric component views, codegen-typed JS↔native contracts, lazy module initialization. The SDK now speaks new-arch directly.
 
@@ -54,9 +54,9 @@ Both releases work in new-arch apps. Pick `2.0.0-alpha` if you want the actual p
 
 Uses Android SDK 2.9.78 & iOS SDK 1.17.0
 
-**Full Changelog**: [1.14.0...2.0.0-alpha.1](https://github.com/100mslive/100ms-react-native/compare/1.14.0...2.0.0-alpha.1)
+**Full Changelog**: [1.13.1...2.0.0-alpha.1](https://github.com/100mslive/100ms-react-native/compare/1.13.1...2.0.0-alpha.1)
 
-## 1.14.0 - 2026-05-07
+## 1.13.1 - 2026-05-07
 
 | Package                     | Version |
 | --------------------------- | ------- |
@@ -68,7 +68,7 @@ Uses Android SDK 2.9.78 & iOS SDK 1.17.0
 
 Uses Android SDK 2.9.78 & iOS SDK 1.17.0
 
-**Full Changelog**: [1.13.0...1.14.0](https://github.com/100mslive/100ms-react-native/compare/1.13.0...1.14.0)
+**Full Changelog**: [1.13.0...1.13.1](https://github.com/100mslive/100ms-react-native/compare/1.13.0...1.13.1)
 
 ## 1.13.0 - 2026-04-30
 

--- a/docs/react-native/v2/release-notes/release-notes.mdx
+++ b/docs/react-native/v2/release-notes/release-notes.mdx
@@ -11,6 +11,57 @@ nav: 4.1
 | @100mslive/react-native-hms          | [![npm](https://img.shields.io/npm/v/@100mslive/react-native-hms)](https://www.npmjs.com/package/@100mslive/react-native-hms)                   |
 | @100mslive/react-native-video-plugin | [![npm](https://img.shields.io/npm/v/@100mslive/react-native-video-plugin)](https://www.npmjs.com/package/@100mslive/react-native-video-plugin) |
 
+## 2.0.0-alpha - 2026-05-15
+
+| Package                              | Version       |
+| ------------------------------------ | ------------- |
+| @100mslive/react-native-hms          | 2.0.0-alpha.1 |
+| @100mslive/react-native-room-kit     | 2.0.0-alpha.0 |
+| @100mslive/react-native-video-plugin | 2.0.0-alpha.0 |
+
+## Highlights
+
+First **alpha release** on React Native's **New Architecture** (TurboModules + Fabric + bridgeless mode). The SDK natively integrates with new-arch apps — no longer relying on RN's Interop Layer shim. Consumers whose apps already use `newArchEnabled=true` can adopt without forking.
+
+**Opt-in install** — `latest` still points at the stable 1.x line, so existing customers are unaffected. To try the alpha:
+
+```bash
+npm install @100mslive/react-native-hms@alpha \
+            @100mslive/react-native-room-kit@alpha \
+            @100mslive/react-native-video-plugin@alpha
+```
+
+### What's new
+
+-   Full New Architecture support — TurboModule + Fabric component view + bridgeless event dispatch
+-   Backwards compatible — the SDK still works under `newArchEnabled=false`
+-   Lazy module initialization — faster cold start; modules load on first JS access instead of at app launch
+-   Codegen-typed JS↔native contract — compile-time enforcement, fewer runtime "wrong-shape" bugs
+
+### Breaking changes
+
+-   **iOS `setupPIP()` rejects instead of crashing.** Previously crashed with "unrecognized selector"; now returns a rejected promise with code `HMS_PLATFORM_UNSUPPORTED`. Add a `.catch()` handler if you weren't already.
+
+-   **`<HMSView />` raw native event `onChange` renamed to `onResolutionChange`.** Only affects code that imported the raw Fabric component directly — the public `HmsView` wrapper exposes no event prop, so consumers using the documented API see no change.
+
+Uses Android SDK 2.9.78 & iOS SDK 1.17.0
+
+**Full Changelog**: [1.14.0...2.0.0-alpha.1](https://github.com/100mslive/100ms-react-native/compare/1.14.0...2.0.0-alpha.1)
+
+## 1.14.0 - 2026-05-07
+
+| Package                     | Version |
+| --------------------------- | ------- |
+| @100mslive/react-native-hms | 1.12.2  |
+
+### react-native-hms
+
+-   **React Native New Architecture Interop Layer support.** The SDK now works in apps with `newArchEnabled=true` via RN's built-in Interop Layer. Resolves [#1428](https://github.com/100mslive/100ms-react-native/issues/1428) where `HMSSDK.build()` crashed on iOS under new-arch + Expo SDK 51 / RN 0.74+. Old-arch consumers see no change in behavior.
+
+Uses Android SDK 2.9.78 & iOS SDK 1.17.0
+
+**Full Changelog**: [1.13.0...1.14.0](https://github.com/100mslive/100ms-react-native/compare/1.13.0...1.14.0)
+
 ## 1.13.0 - 2026-04-30
 
 | Package                          | Version |

--- a/docs/react-native/v2/release-notes/release-notes.mdx
+++ b/docs/react-native/v2/release-notes/release-notes.mdx
@@ -31,6 +31,14 @@ npm install @100mslive/react-native-hms@alpha \
             @100mslive/react-native-video-plugin@alpha
 ```
 
+### Phase 0 (1.14.0) → Phase 1 (2.0.0-alpha)
+
+`1.14.0` made the SDK *survive* under new-arch apps via React Native's **Interop Layer** — a built-in shim that translates new-arch calls back to the old module API. The SDK's internals stayed old-arch; the Interop Layer did the translation. Useful, but you pay a translation cost on every call and can't reach the new-arch performance benefits.
+
+`2.0.0-alpha` replaces the shim with **native new-arch implementation**: TurboModule entry points, Fabric component views, codegen-typed JS↔native contracts, lazy module initialization. The SDK now speaks new-arch directly.
+
+Both releases work in new-arch apps. Pick `2.0.0-alpha` if you want the actual performance benefits (synchronous view measurement, lower per-call overhead, faster cold start) — or if you use libraries that require a fully native new-arch dep tree (`react-native-reanimated` 4.x, `react-native-gesture-handler` 2.31+, etc.).
+
 ### What's new
 
 -   Full New Architecture support — TurboModule + Fabric component view + bridgeless event dispatch


### PR DESCRIPTION
Two release entries added to `docs/react-native/v2/release-notes/release-notes.mdx`:

### `2.0.0-alpha` (2026-05-15)
First alpha on React Native's New Architecture (TurboModules + Fabric + bridgeless mode). Three packages, all on the npm `alpha` dist-tag:
- `@100mslive/react-native-hms@2.0.0-alpha.1`
- `@100mslive/react-native-room-kit@2.0.0-alpha.0`
- `@100mslive/react-native-video-plugin@2.0.0-alpha.0`

Calls out the two breaking changes (`setupPIP` rejection on iOS, raw Fabric component event rename) and the opt-in install snippet. `latest` stays on 1.x — existing customers unaffected.

### `1.14.0` (2026-05-07) — backfill
Phase 0 Interop Layer release that shipped as `@100mslive/react-native-hms@1.12.2` but never got its own docs entry. Unblocks customers on apps with `newArchEnabled=true` via RN's built-in Interop Layer (no Codegen authoring yet — that came in 2.0.0-alpha).

A retroactive GitHub release tagged `1.14.0` (pointing at commit `72399dc6` on the SDK repo) will follow separately.