### PR TITLE
docs(firewall): add us-east5 TURN server IPs

### DIFF
--- a/docs/server-side/v2/how-to-guides/firewall-and-ports.mdx
+++ b/docs/server-side/v2/how-to-guides/firewall-and-ports.mdx
@@ -46,6 +46,14 @@ For smooth call experience add following domains and ports to your firewall whit
 34.169.128.194/32
 34.105.5.246/32
 34.169.40.88/32
+34.162.177.21/32
+34.162.64.171/32
+34.153.30.136/32
+34.162.229.129/32
+34.162.204.39/32
+34.127.169.122/32
+34.162.40.97/32
+34.162.96.160/32
 ```
 
 ### NAT gateway IP address whitelisting for webhooks


### PR DESCRIPTION
## Summary
- Add 8 new us-east5 TURN server IPs to the firewall whitelist in `docs/server-side/v2/how-to-guides/firewall-and-ports.mdx` so customers whitelisting outbound traffic can reach the new cloud-NAT egress and TURN frontends.

New IPs added (all `/32`):
- 34.162.177.21 (prod-us5-turn-cloud-nat-ip-2)
- 34.162.64.171 (prod-us5-turn-cloud-nat-ip-2)
- 34.153.30.136 (prod-us5-turn-cloud-nat-ip-3)
- 34.162.229.129 (prod-us5-turn-cloud-nat-ip-4)
- 34.162.204.39 (prod-us5-turn-cloud-nat-ip-5)
- 34.127.169.122 (prod-us5-turn-ip)
- 34.162.40.97 (prod-us5-turn-ip-2)
- 34.162.96.160 (prod-us5-turn-ip-3)

## Test plan
- [ ] Preview the rendered page and confirm the new IPs appear in the "Turn server IP address" list under Configure firewall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)