### PR TITLE
docs: add 0.14.3 web SDK release notes

### DIFF
--- a/docs/javascript/v2/release-notes/release-notes.mdx
+++ b/docs/javascript/v2/release-notes/release-notes.mdx
@@ -14,6 +14,18 @@ description: Release Notes for 100ms.live JavaScript SDK
 | @100mslive/hms-noise-cancellation | [![npm version](https://badge.fury.io/js/%40100mslive%2Fhms-noise-cancellation.svg)](https://badge.fury.io/js/%40100mslive%2Fhms-noise-cancellation) |
 | @100mslive/hms-virtual-background | [![npm version](https://badge.fury.io/js/%40100mslive%2Fhms-virtual-background.svg)](https://badge.fury.io/js/%40100mslive%2Fhms-virtual-background) |
 
+## 2026-06-17
+
+Released: `@100mslive/hms-video-store@0.14.3`, `@100mslive/react-sdk@0.12.3`, `@100mslive/hls-player@0.5.3`, `@100mslive/roomkit-react@0.5.3`, `@100mslive/hms-whiteboard@0.2.3`, `@100mslive/hms-virtual-background@1.15.3`
+
+### Added:
+
+-   Roomkit Prebuilt: Incoming chat messages now surface as a transient, bottom-anchored bubble on the Picture-in-Picture canvas — it shows the sender name and a single line of text and auto-dismisses after 4s, so users don't miss chat while the tab is backgrounded
+
+### Fixed:
+
+-   Resolved Dependabot security advisories and aligned all `esbuild` copies to `0.28.1`
+
 ## 2026-05-20
 
 Released: `@100mslive/hms-video-store@0.14.2`, `@100mslive/react-sdk@0.12.2`, `@100mslive/hls-player@0.5.2`, `@100mslive/roomkit-react@0.5.2`, `@100mslive/hms-whiteboard@0.2.2`, `@100mslive/hms-virtual-background@1.15.2`


### PR DESCRIPTION
Adds the release-notes entry for web SDK 0.14.3 (`hms-video-store@0.14.3` / `roomkit-react@0.5.3`): the Roomkit Prebuilt incoming-chat bubble in Picture-in-Picture, plus dependency/security updates.