### PR TITLE
docs: release notes for camera-recovery-after-background fix (RN + Android)

### DIFF
--- a/docs/android/v2/release-notes/release-notes.mdx
+++ b/docs/android/v2/release-notes/release-notes.mdx
@@ -19,6 +19,10 @@ import AndroidPrebuiltVersionShield from '@/common/android-prebuilt-version-shie
 | live.100ms:virtual-background: |<AndroidSdkVersionShield />|
 | live.100ms:hms-noise-cancellation-android: | <AndroidSdkVersionShield /> |
 
+## v2.9.84 - 2026-06-19
+### Fixed
+* Fixed the local peer's video appearing black/frozen to remote peers after the app returned from the background. When the app is fully backgrounded, Android revokes the camera; the SDK now automatically re-acquires it when the app returns to the foreground (previously the published video stayed frozen until the user manually toggled their video).
+
 ## v2.9.83 - 2026-04-10
 ### Fixed
 * Improved Bluetooth permission handling on Android 12+ — the SDK now declares `BLUETOOTH_CONNECT` in the manifest and detects when it is missing at runtime.

--- a/docs/react-native/v2/release-notes/release-notes.mdx
+++ b/docs/react-native/v2/release-notes/release-notes.mdx
@@ -11,6 +11,43 @@ nav: 4.1
 | @100mslive/react-native-hms          | [![npm](https://img.shields.io/npm/v/@100mslive/react-native-hms)](https://www.npmjs.com/package/@100mslive/react-native-hms)                   |
 | @100mslive/react-native-video-plugin | [![npm](https://img.shields.io/npm/v/@100mslive/react-native-video-plugin)](https://www.npmjs.com/package/@100mslive/react-native-video-plugin) |
 
+## 1.13.2 - 2026-06-22
+
+Patch release. Fixes the local peer's video appearing black/frozen to remote peers after the app is backgrounded.
+
+| Package                          | Version |
+| -------------------------------- | ------- |
+| @100mslive/react-native-hms      | 1.12.3  |
+| @100mslive/react-native-room-kit | 1.3.2   |
+
+### react-native-hms
+
+-   **Fixed: peer video goes black/frozen on the remote side after the app is backgrounded.** When the app was sent to the background while publishing video, Android revoked the camera and the local peer's video stayed frozen/black for remote peers until they manually toggled (mute/unmute) their video. The bundled native Android SDK is bumped to `2.9.84`, which automatically re-acquires the camera when the app returns to the foreground. ([#1666](https://github.com/100mslive/100ms-react-native/issues/1666))
+
+### react-native-room-kit
+
+-   Bumps the `@100mslive/react-native-hms` peer dependency to `1.12.3` to pick up the camera-recovery fix above.
+
+## 2.0.0-alpha.3 - 2026-06-22
+
+Patch release for the **2.0.0-alpha** track — forward-ports the camera-recovery-after-background fix to the new-architecture line.
+
+| Package                              | Version       |
+| ------------------------------------ | ------------- |
+| @100mslive/react-native-hms          | 2.0.0-alpha.3 |
+| @100mslive/react-native-room-kit     | 2.0.0-alpha.2 |
+| @100mslive/react-native-video-plugin | 2.0.0-alpha.0 |
+
+`latest` still points at the `1.x` line — existing customers are unaffected.
+
+### react-native-hms
+
+-   Same camera-recovery fix as `1.12.3` (bundled native Android SDK `2.9.84`): re-acquires the camera when the app returns to the foreground after the OS revokes it while backgrounded. ([#1666](https://github.com/100mslive/100ms-react-native/issues/1666))
+
+### react-native-room-kit
+
+-   Bumps the `@100mslive/react-native-hms` peer dependency to `2.0.0-alpha.3`.
+
 ## 2.0.0-alpha.2 - 2026-05-21
 
 Patch release for the **2.0.0-alpha** track. Fixes an iOS build failure under `use_frameworks! :linkage => :static` — the default Podfile setting in Expo SDK 54+. Bare React Native apps and Expo SDK ≤53 were not affected by alpha.1.


### PR DESCRIPTION
Adds release-notes entries for the camera-recovery-after-background fix (#1666 — local peer's video went black/frozen for remote peers after backgrounding; SDK now re-acquires the camera on foreground).

**React Native** (`docs/react-native/v2/release-notes/release-notes.mdx`):
- `1.13.2` — hms `1.12.3` + room-kit `1.3.2` (stable / Latest)
- `2.0.0-alpha.3` — hms `2.0.0-alpha.3` + room-kit `2.0.0-alpha.2` (new-arch alpha)

**Android** (`docs/android/v2/release-notes/release-notes.mdx`):
- `v2.9.84` — the native SDK fix that re-acquires the camera on app foreground.

Mirrors the published npm/Maven releases and the GitHub releases (`1.13.2` Latest, `2.0.0-alpha.3` Pre-release, android-sdk `2.9.84`).