### PR TITLE
docs: re-attach video when a peer's track id changes

### DIFF
--- a/docs/javascript/v2/how-to-guides/set-up-video-conferencing/render-video/overview.mdx
+++ b/docs/javascript/v2/how-to-guides/set-up-video-conferencing/render-video/overview.mdx
@@ -35,37 +35,39 @@ hmsActions.detachVideo(videoTrack.id, videoElement);
 
 ## When to attach/detach videos
 
-Starting from this [release](https://www.100ms.live/docs/javascript/v2/changelog/release-notes#2023-03-14), sdk handles the subsequent attach/detach automatically.
-- attach needs to be called only the first time the video element is available. subsequent calls will be ignored.
+Starting from this [release](https://www.100ms.live/docs/javascript/v2/changelog/release-notes#2023-03-14), sdk handles the subsequent attach/detach automatically **for a given track**.
+- attach needs to be called once per track id. Repeat calls for the same track id are ignored, and the sdk takes care of mute/unmute, plugins and going in and out of view on its own.
 - detach needs to be called only when the element is removed from the dom while the track is still available. For the majority of cases, calling detach won't be needed.
 
-To disable the auto handling by sdk, pass `autoManageVideo: false` in join or preview config object. Then you will have to follow the below snippet
-to handle video rendering on your end.
+<Note type="warning">
+A peer's video track id is <b>not</b> fixed for the whole call. It changes when they switch camera, and when we move their session to another media server. The sdk's auto handling is scoped to one track id, so it cannot carry an element across to the replacement track — you have to attach again.
 
-We need to re-attach video when it's in view after every:
+Attaching once to `peer.videoTrack` and never again will leave the tile frozen from the moment the track id changes. Subscribe by <b>peer id</b> instead, so you always receive that peer's current track.
+</Note>
 
-1. Unmute(when track.enable is true)
-2. Plugin is added/removed(for example, enable/disable virtual background)
-3. Camera/device change(track.deviceId is changed)
+So re-attach whenever the peer's video **track id** changes. That covers:
 
-You can achieve all this by using the `selectVideoTrackByID` selector and the aforementioned `hmsActions.attachVideo` and `hmsActions.detachVideo` functions.
+1. Camera/device change
+2. The session moving to another media server
+3. Any other republish of that peer's video
+
+Use the `selectVideoTrackByPeerID` selector with `hmsActions.attachVideo` and `hmsActions.detachVideo`:
 
 ```js
-// assuming you have peer object and video element
+// assuming you have a peer object and a video element
 // complete code snippet below
+let attachedTrackId = null;
+
 hmsStore.subscribe((track) => {
-    if (!track) {
-        return;
-    }
-    if (track?.enabled) {
-        hmsActions.attachVideo(track.id, videoElement);
-    } else {
-        hmsActions.detachVideo(track.id, videoElement);
-    }
-}, selectVideoTrackByID(peer.videoTrack));
+    const nextTrackId = track?.id ?? null;
+    if (nextTrackId === attachedTrackId) return; // same track, e.g. mute/unmute - nothing to do
+    if (attachedTrackId) hmsActions.detachVideo(attachedTrackId, videoElement);
+    if (nextTrackId) hmsActions.attachVideo(nextTrackId, videoElement);
+    attachedTrackId = nextTrackId;
+}, selectVideoTrackByPeerID(peer.id));
 ```
 
-> Note that if you're using the `useVideo` hook from `react-sdk` this is already being taken care of.
+If you are on React, the `useVideo` hook from `react-sdk` already does exactly this — pass it `peer.videoTrack` and it re-attaches for you.
 
 ## Example Snippet
 
@@ -92,20 +94,21 @@ function renderPeer(peer) {
     videoElement.playsinline = true;
     peerTileName.textContent = peer.name;
 
+    // Subscribe by peer id, not track id: a peer's track id changes on camera switch
+    // and when their session moves to another server. Re-attach whenever it changes.
+    let attachedTrackId = null;
     hmsStore.subscribe((track) => {
-        if (!track) {
-            return;
-        }
-        if (track.enabled) {
-            hmsActions.attachVideo(track.id, videoElement);
-        } else {
-            hmsActions.detachVideo(track.id, videoElement);
-        }
-    }, selectVideoTrackByID(peer.videoTrack));
+        const nextTrackId = track?.id ?? null;
+        if (nextTrackId === attachedTrackId) return; // same track, e.g. mute/unmute
+        if (attachedTrackId) hmsActions.detachVideo(attachedTrackId, videoElement);
+        if (nextTrackId) hmsActions.attachVideo(nextTrackId, videoElement);
+        attachedTrackId = nextTrackId;
+    }, selectVideoTrackByPeerID(peer.id));
 
     peerTileDiv.append(videoElement);
     peerTileDiv.append(peerTileName);
 
+    // Tile creation stays keyed on peer id so the element is not rebuilt on every change
     renderedPeerIDs.add(peer.id);
     return peerTileDiv;
 }
@@ -119,7 +122,7 @@ function renderPeers(peers) {
             console.log(
                 `rendering video for peer - ${peer.name}, roleName - ${peer.roleName}, isLocal- ${peer.isLocal}`
             );
-            peersContainer.append(renderVideo(peer));
+            peersContainer.append(renderPeer(peer));
         }
     });
 }

--- a/docs/javascript/v2/how-to-guides/set-up-video-conferencing/render-video/overview.mdx
+++ b/docs/javascript/v2/how-to-guides/set-up-video-conferencing/render-video/overview.mdx
@@ -36,20 +36,16 @@ hmsActions.detachVideo(videoTrack.id, videoElement);
 ## When to attach/detach videos
 
 Starting from this [release](https://www.100ms.live/docs/javascript/v2/changelog/release-notes#2023-03-14), sdk handles the subsequent attach/detach automatically **for a given track**.
-- attach needs to be called once per track id. Repeat calls for the same track id are ignored, and the sdk takes care of mute/unmute, plugins and going in and out of view on its own.
+- attach needs to be called once per track id. Repeat calls for the same track id are ignored, and the sdk takes care of mute/unmute, plugins, camera/device change and going in and out of view on its own. None of these change the peer's track id.
 - detach needs to be called only when the element is removed from the dom while the track is still available. For the majority of cases, calling detach won't be needed.
 
 <Note type="warning">
-A peer's video track id is <b>not</b> fixed for the whole call. It changes when they switch camera, and when we move their session to another media server. The sdk's auto handling is scoped to one track id, so it cannot carry an element across to the replacement track — you have to attach again.
+When a session is moved to another media server, every peer republishes and `peer.videoTrack` becomes a <b>new</b> track id. The sdk's auto handling is scoped to one track id, so it cannot carry your element across to the replacement track.
 
-Attaching once to `peer.videoTrack` and never again will leave the tile frozen from the moment the track id changes. Subscribe by <b>peer id</b> instead, so you always receive that peer's current track.
+If you attach once to `peer.videoTrack` and never subscribe to changes, the tile freezes the moment that happens and stays frozen for the rest of the call. Subscribe by <b>peer id</b> instead, so you always receive that peer's current track, and re-attach when the id changes.
 </Note>
 
-So re-attach whenever the peer's video **track id** changes. That covers:
-
-1. Camera/device change
-2. The session moving to another media server
-3. Any other republish of that peer's video
+Server migration needs no action from your app or your users, so it is the case that gets missed. The only other way `peer.videoTrack` changes is a real unpublish and republish of that peer's video — for example a role change to a role that cannot publish video, and then back to one that can.
 
 Use the `selectVideoTrackByPeerID` selector with `hmsActions.attachVideo` and `hmsActions.detachVideo`:
 
@@ -94,8 +90,8 @@ function renderPeer(peer) {
     videoElement.playsinline = true;
     peerTileName.textContent = peer.name;
 
-    // Subscribe by peer id, not track id: a peer's track id changes on camera switch
-    // and when their session moves to another server. Re-attach whenever it changes.
+    // Subscribe by peer id, not track id: a peer's track id changes when their session
+    // moves to another media server. Re-attach whenever it changes.
     let attachedTrackId = null;
     hmsStore.subscribe((track) => {
         const nextTrackId = track?.id ?? null;

--- a/docs/javascript/v2/quickstart/javascript-quickstart.mdx
+++ b/docs/javascript/v2/quickstart/javascript-quickstart.mdx
@@ -71,7 +71,7 @@ import {
   selectIsLocalVideoEnabled,
   selectPeers,
   selectIsConnectedToRoom,
-  selectVideoTrackByID,
+  selectVideoTrackByPeerID,
 } from "@100mslive/hms-video-store";
 
 // Initialize HMS Store
@@ -132,16 +132,18 @@ function renderPeer(peer) {
   videoElement.playsinline = true;
   peerTileName.textContent = peer.name;
 
+  // A peer's video track id is not fixed for the whole call - it changes when they
+  // switch camera, and when we move their session to another server. Subscribe by
+  // peer id so you always get their *current* track, and re-attach when it changes.
+  // Attaching once to peer.videoTrack would leave the tile frozen after any of these.
+  let attachedTrackId = null;
   hmsStore.subscribe((track) => {
-    if (!track) {
-      return;
-    }
-    if (track.enabled) {
-      hmsActions.attachVideo(track.id, videoElement);
-    } else {
-      hmsActions.detachVideo(track.id, videoElement);
-    }
-  }, selectVideoTrackByID(peer.videoTrack));
+    const nextTrackId = track?.id ?? null;
+    if (nextTrackId === attachedTrackId) return; // same track, e.g. mute/unmute - nothing to do
+    if (attachedTrackId) hmsActions.detachVideo(attachedTrackId, videoElement);
+    if (nextTrackId) hmsActions.attachVideo(nextTrackId, videoElement);
+    attachedTrackId = nextTrackId;
+  }, selectVideoTrackByPeerID(peer.id));
 
   peerTileDiv.append(videoElement);
   peerTileDiv.append(peerTileName);

--- a/docs/javascript/v2/quickstart/javascript-quickstart.mdx
+++ b/docs/javascript/v2/quickstart/javascript-quickstart.mdx
@@ -132,10 +132,10 @@ function renderPeer(peer) {
   videoElement.playsinline = true;
   peerTileName.textContent = peer.name;
 
-  // A peer's video track id is not fixed for the whole call - it changes when they
-  // switch camera, and when we move their session to another server. Subscribe by
-  // peer id so you always get their *current* track, and re-attach when it changes.
-  // Attaching once to peer.videoTrack would leave the tile frozen after any of these.
+  // A peer's video track id is not fixed for the whole call - it becomes a new id when
+  // their session is moved to another media server. Subscribe by peer id so you always
+  // get their *current* track, and re-attach when it changes. Attaching once to
+  // peer.videoTrack would leave the tile frozen from that point on.
   let attachedTrackId = null;
   hmsStore.subscribe((track) => {
     const nextTrackId = track?.id ?? null;


### PR DESCRIPTION
The JavaScript quickstart and render-video examples subscribed with `selectVideoTrackByID(peer.videoTrack)`, which snapshots the track id at first render. When a session is moved to another media server the peer republishes and that id changes, so the tile stayed attached to a track that no longer existed and froze.

These now subscribe with `selectVideoTrackByPeerID(peer.id)` and re-attach when the id changes. The "attach only the first time" guidance is scoped to a single track id, and camera/device change, mute/unmute and plugins are called out as cases the sdk already handles without a new track id. Also fixes a `renderVideo`/`renderPeer` typo that stopped the sample running as written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)