### PR TITLE
docs: note the version from which sessions are migrated

### DIFF
--- a/docs/javascript/v2/how-to-guides/set-up-video-conferencing/render-video/overview.mdx
+++ b/docs/javascript/v2/how-to-guides/set-up-video-conferencing/render-video/overview.mdx
@@ -47,6 +47,8 @@ If you attach once to `peer.videoTrack` and never subscribe to changes, the tile
 
 Server migration needs no action from your app or your users, so it is the case that gets missed. The only other way `peer.videoTrack` changes is a real unpublish and republish of that peer's video — for example a role change to a role that cannot publish video, and then back to one that can.
 
+A session is only moved for clients on `@100mslive/hms-video-store` 0.12.17 or newer; older clients are left on their current server. The unpublish and republish case applies on every version, so subscribe by peer id whichever version you are on.
+
 Use the `selectVideoTrackByPeerID` selector with `hmsActions.attachVideo` and `hmsActions.detachVideo`:
 
 ```js

--- a/docs/javascript/v2/how-to-guides/set-up-video-conferencing/render-video/overview.mdx
+++ b/docs/javascript/v2/how-to-guides/set-up-video-conferencing/render-video/overview.mdx
@@ -47,7 +47,7 @@ If you attach once to `peer.videoTrack` and never subscribe to changes, the tile
 
 Server migration needs no action from your app or your users, so it is the case that gets missed. The only other way `peer.videoTrack` changes is a real unpublish and republish of that peer's video — for example a role change to a role that cannot publish video, and then back to one that can.
 
-A session is only moved for clients on `@100mslive/hms-video-store` 0.12.17 or newer; older clients are left on their current server. The unpublish and republish case applies on every version, so subscribe by peer id whichever version you are on.
+A session is only moved for clients on `@100mslive/hms-video-store` [0.12.17](/javascript/v2/release-notes/release-notes) or newer; older clients are left on their current server. The unpublish and republish case applies on every version, so subscribe by peer id whichever version you are on.
 
 Use the `selectVideoTrackByPeerID` selector with `hmsActions.attachVideo` and `hmsActions.detachVideo`:
 


### PR DESCRIPTION
The render-video guide explains that `peer.videoTrack` gets a new id when a session is moved to another media server, but not which clients that applies to. Sessions are only moved for clients on `@100mslive/hms-video-store` 0.12.17 or newer — below that the server leaves the session where it is. The version links to the release notes, like the release reference at the top of the same section.

Also notes that the unpublish and republish case still applies on every version, so the re-attach guidance is unconditional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)