### PR TITLE
docs(android): 2.9.86 release notes

### DIFF
--- a/docs/android/v2/release-notes/release-notes.mdx
+++ b/docs/android/v2/release-notes/release-notes.mdx
@@ -19,6 +19,11 @@ import AndroidPrebuiltVersionShield from '@/common/android-prebuilt-version-shie
 | live.100ms:virtual-background: |<AndroidSdkVersionShield />|
 | live.100ms:hms-noise-cancellation-android: | <AndroidSdkVersionShield /> |
 
+## v2.9.86 - 2026-08-26
+### Fixed
+* Fixed still-image capture (`captureImageAtMaxResolution`) failing with error code 8001 on some devices. The camera image buffer is now released on every capture path — preventing a leak that could make subsequent captures fail — and a failed capture can no longer crash the app.
+* Restored the still-capture timeout to 5 seconds so slower captures on lower-end devices complete instead of timing out.
+
 ## v2.9.85 - 2026-08-05
 ### Fixed
 * Fixed a low-volume production crash in the ICE-failure retry path.


### PR DESCRIPTION
Adds the **v2.9.86** entry to the Android SDK release notes — the still-image-capture fixes (android-sdk #964): ImageReader leak cleanup on all capture paths, listener hardening so a failed capture can't crash the app, and the still-capture timeout restored to 5s.

Note: date is a placeholder (2026-08-26) — update to the actual release date when 2.9.86 ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)